### PR TITLE
Fit whole route in bounds rather than just start and finish waypoints

### DIFF
--- a/source/components/Map/index.js
+++ b/source/components/Map/index.js
@@ -179,10 +179,8 @@ class Map extends React.Component {
   }
 
   focusOnRoute (routes) {
-    this._map.fitBounds([
-      first((first(routes) || {}).waypoints),
-      last((last(routes) || {}).waypoints)
-    ], { padding: [50, 50] })
+    const waypoints = routes.reduce((routes, route) => routes.concat(route.waypoints), [])
+    this._map.fitBounds(waypoints, { padding: [50, 50] })
   }
 
   openTourerPopup (marker) {
@@ -357,9 +355,7 @@ class Map extends React.Component {
     this.renderStartAndFinish(firstPoint, lastPoint)
     this.renderWaypoints(routes)
     if (focus) {
-      this._map.fitBounds([firstPoint, lastPoint], {
-        padding: [50, 50]
-      })
+      this.focusOnRoute(routes)
     }
   }
 

--- a/source/components/Map/index.js
+++ b/source/components/Map/index.js
@@ -179,7 +179,7 @@ class Map extends React.Component {
   }
 
   focusOnRoute (routes) {
-    const waypoints = routes.reduce((routes, route) => routes.concat(route.waypoints), [])
+    const waypoints = routes.reduce((waypoints, route) => waypoints.concat(route.waypoints), [])
     this._map.fitBounds(waypoints, { padding: [50, 50] })
   }
 


### PR DESCRIPTION
Issue is with routes that loop around to some degree e.g. the one I am working on starts in Perth, loops up through the NT and then back down to Victoria, so fitBounds fits in the start and finish waypoints, but the top part of the track (including tourers) in that portion of the track, are not initially visible.
