### PR TITLE
Calculate Bearing

### DIFF
--- a/examples/source/cross-continent/index.js
+++ b/examples/source/cross-continent/index.js
@@ -18,10 +18,11 @@ const US_WAYPOINTS = [
   { lat: 40.7128, lng: -74.0059}
 ]
 
-const TOURERS = [
-  { id: '1', distance: 1000000 },
-  { id: '2', distance: 6000000 }
-]
+// want to test with a lot of riders on the route
+const TOURERS = Array.apply(null, Array(100)).map((item, index) => ({
+  id: `${index}`,
+  distance: 500000 * index
+}))
 
 const INITIAL_STATE = {
   routes: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tour-tracker",
-  "version": "1.0.1-19",
+  "version": "1.0.1-20",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tour-tracker",
-  "version": "1.0.1-20",
+  "version": "1.0.1-19",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/source/actions/index.js
+++ b/source/actions/index.js
@@ -12,9 +12,9 @@ const requestRoute = (index) => ({
   payload: { index }
 })
 
-const receiveRouteSuccess = (index, points) => ({
+const receiveRouteSuccess = (index, { points, distance }) => ({
   type: RECEIVE_ROUTE_SUCCESS,
-  payload: { index, points }
+  payload: { index, points, distance }
 })
 
 const receiveRouteFailure = (index, error) => ({

--- a/source/components/Map/__tests__/index.js
+++ b/source/components/Map/__tests__/index.js
@@ -70,9 +70,10 @@ const createSampleMap = (args = {}) => {
           [0, 50]
         ],
         points: [
-          { lat: 0, lng: 0, distance: 0 },
-          { lat: 0, lng: 50, distance: 5560000 }
-        ]
+          { lat: 0, lng: 0 },
+          { lat: 0, lng: 50 }
+        ],
+        distance: 5560000
       }
     ],
     tourers = [
@@ -227,9 +228,10 @@ describe('Map', () => {
             [0, 50]
           ],
           points: [
-            { lat: 0, lng: 0, distance: 0 },
-            { lat: 0, lng: 50, distance: 5560000 }
-          ]
+            { lat: 0, lng: 0 },
+            { lat: 0, lng: 50 }
+          ],
+          distance: 5560000
         },
         {
           waypoints: [
@@ -237,9 +239,10 @@ describe('Map', () => {
             [0, 150]
           ],
           points: [
-            { lat: 0, lng: 100, distance: 0 },
-            { lat: 0, lng: 150, distance: 5560000 }
-          ]
+            { lat: 0, lng: 100 },
+            { lat: 0, lng: 150 }
+          ],
+          distance: 5560000
         }
       ],
       tourers: [

--- a/source/components/Map/__tests__/index.js
+++ b/source/components/Map/__tests__/index.js
@@ -70,7 +70,7 @@ const createSampleMap = (args = {}) => {
           [0, 50]
         ],
         points: [
-          { lat: 0, lng: 0, distance: 0, bearing: 90 },
+          { lat: 0, lng: 0, distance: 0 },
           { lat: 0, lng: 50, distance: 5560000 }
         ]
       }
@@ -227,7 +227,7 @@ describe('Map', () => {
             [0, 50]
           ],
           points: [
-            { lat: 0, lng: 0, distance: 0, bearing: 90 },
+            { lat: 0, lng: 0, distance: 0 },
             { lat: 0, lng: 50, distance: 5560000 }
           ]
         },
@@ -237,7 +237,7 @@ describe('Map', () => {
             [0, 150]
           ],
           points: [
-            { lat: 0, lng: 100, distance: 0, bearing: 90 },
+            { lat: 0, lng: 100, distance: 0 },
             { lat: 0, lng: 150, distance: 5560000 }
           ]
         }

--- a/source/components/Map/index.js
+++ b/source/components/Map/index.js
@@ -16,12 +16,13 @@ const NullPoint = {
 
 const findTourerStartingPoint = (distance, { points }) => {
   let total = 0
-  
+
   for (let i = 0; i < points.length - 1; i++) {
     total += calcDistance(points[i], points[i + 1])
     if (distance < total) {
       return {
         startPoint: points[i],
+        nextPoint: points[i + 1],
         currentBearingDistance: total - distance
       }
     }
@@ -30,15 +31,6 @@ const findTourerStartingPoint = (distance, { points }) => {
   return {
     startPoint: last(points),
     currentBearingDistance: 0
-  }
-}
-
-const findTourerNextPoint = (currentRoute, currentPoint) => {
-  const nextIndex = currentRoute.points.indexOf(currentPoint) + 1
-  if (!nextIndex || nextIndex === currentRoute.points.length) {
-    return undefined
-  } else {
-    return currentRoute.points[nextIndex]
   }
 }
 
@@ -56,8 +48,7 @@ const calcTourerPosition = (distance, routes) => {
 
   const tourersCurrentRoute = findTourersCurrentRoute(distance, routes)
   const distanceIntoRoute = distance - tourersCurrentRoute.start
-  const { startPoint, currentBearingDistance } = findTourerStartingPoint(distanceIntoRoute, tourersCurrentRoute)
-  const nextPoint = findTourerNextPoint(tourersCurrentRoute, startPoint)
+  const { startPoint, nextPoint, currentBearingDistance } = findTourerStartingPoint(distanceIntoRoute, tourersCurrentRoute)
 
   const lat = toRad(startPoint.lat) || 0
   const lng = toRad(startPoint.lng) || 0

--- a/source/components/Map/index.js
+++ b/source/components/Map/index.js
@@ -25,8 +25,6 @@ const findTourerStartingPoint = (distance, route) => (
 
 const findTourerNextPoint = (currentRoute, currentPoint) => {
   const nextIndex = currentRoute.points.indexOf(currentPoint) + 1
-  console.log('nextIndex', nextIndex)
-  console.log('currentPoint', currentPoint)
   if (!nextIndex || nextIndex === currentRoute.points.length) {
     return undefined
   } else {

--- a/source/reducer/index.js
+++ b/source/reducer/index.js
@@ -12,8 +12,6 @@ const updateItem = (collection, index, attributes) => ([
   ...collection.slice(index + 1)
 ])
 
-const reducePoints = (points) => points.map(({ lat, lng, distance }) => ({ lat, lng, distance }))
-
 const requestRoute = (state, { index }) => ({
   ...state,
   routes: updateItem(state.routes, index, { status: 'fetching' })
@@ -24,9 +22,9 @@ const receiveRouteFailure = (state, { index, error }) => ({
   routes: updateItem(state.routes, index, { status: 'failed', error })
 })
 
-const receiveRouteSuccess = (state, { index, points }) => ({
+const receiveRouteSuccess = (state, { index, points, distance }) => ({
   ...state,
-  routes: updateItem(state.routes, index, { status: 'fetched', error: '', points: reducePoints(points) })
+  routes: updateItem(state.routes, index, { status: 'fetched', error: '', points, distance })
 })
 
 const selectTourer = (state, { id }) => ({

--- a/source/reducer/index.js
+++ b/source/reducer/index.js
@@ -12,6 +12,8 @@ const updateItem = (collection, index, attributes) => ([
   ...collection.slice(index + 1)
 ])
 
+const reducePoints = (points) => points.map(({ lat, lng, distance }) => ({ lat, lng, distance }))
+
 const requestRoute = (state, { index }) => ({
   ...state,
   routes: updateItem(state.routes, index, { status: 'fetching' })
@@ -24,7 +26,7 @@ const receiveRouteFailure = (state, { index, error }) => ({
 
 const receiveRouteSuccess = (state, { index, points }) => ({
   ...state,
-  routes: updateItem(state.routes, index, { status: 'fetched', error: '', points })
+  routes: updateItem(state.routes, index, { status: 'fetched', error: '', points: reducePoints(points) })
 })
 
 const selectTourer = (state, { id }) => ({

--- a/source/utils/index.js
+++ b/source/utils/index.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { decode } from 'polyline'
+import memoize from 'lodash/memoize'
 import { EARTHS_RADIUS_IN_METERS } from '../constants'
 
 export const toRad = (value) => (value * Math.PI / 180)
@@ -23,23 +24,28 @@ export const calcBearing = (fromPoint, toPoint) => {
   return (toDeg(Math.atan2(x, y)) + 360) % 360
 }
 
-export const calcDistance = (fromPoint, toPoint) => {
-  const xA = toRad(fromPoint.lat)
-  const yA = toRad(fromPoint.lng)
-  const xB = toRad(toPoint.lat)
-  const yB = toRad(toPoint.lng)
-  const deltaY = yB - yA
+export const calcDistance = memoize(
+  (fromPoint, toPoint) => {
+    const xA = toRad(fromPoint.lat)
+    const yA = toRad(fromPoint.lng)
+    const xB = toRad(toPoint.lat)
+    const yB = toRad(toPoint.lng)
+    const deltaY = yB - yA
 
-  if (xA === xB && yA === yB) {
-    return 0
-  }
+    if (xA === xB && yA === yB) {
+      return 0
+    }
 
-  return Math.acos(Math.min(
-    Math.sin(xA) * Math.sin(xB) +
-    Math.cos(xA) * Math.cos(xB) *
-    Math.cos(deltaY)
-  ), 1) * EARTHS_RADIUS_IN_METERS
-}
+    return Math.acos(Math.min(
+      Math.sin(xA) * Math.sin(xB) +
+      Math.cos(xA) * Math.cos(xB) *
+      Math.cos(deltaY)
+    ), 1) * EARTHS_RADIUS_IN_METERS
+  },
+  (fromPoint, toPoint) => (
+    `${fromPoint.lat}/${fromPoint.lng}/${toPoint.lat}/${toPoint.lng}`
+  )
+)
 
 const polylineToPoints = (routeGeometry = '') => (
   decode(routeGeometry).map((point) => {

--- a/source/utils/index.js
+++ b/source/utils/index.js
@@ -8,15 +8,13 @@ export const toDeg = (value) => (value / Math.PI * 180)
 export const first = (arr = []) => arr.slice(0)[0]
 export const last = (arr = []) => arr.slice(0)[arr.length - 1]
 
-const calcBearing = (
-  [latA, lonA],
-  [latB, lonB]
-) => {
-  const xA = toRad(latA)
-  const yA = toRad(lonA)
-  const xB = toRad(latB)
-  const yB = toRad(lonB)
+export const calcBearing = (fromPoint, toPoint) => {
+  const xA = toRad(fromPoint.lat)
+  const yA = toRad(fromPoint.lng)
+  const xB = toRad(toPoint.lat)
+  const yB = toRad(toPoint.lng)
   const deltaY = yB - yA
+
   const x = Math.cos(xB) * Math.sin(deltaY)
   const y = Math.cos(xA) * Math.sin(xB) -
             Math.sin(xA) * Math.cos(xB) *
@@ -25,14 +23,11 @@ const calcBearing = (
   return (toDeg(Math.atan2(x, y)) + 360) % 360
 }
 
-const calcDistance = (
-  [latA, lonA],
-  [latB, lonB]
-) => {
-  const xA = toRad(latA)
-  const yA = toRad(lonA)
-  const xB = toRad(latB)
-  const yB = toRad(lonB)
+export const calcDistance = (fromPoint, toPoint) => {
+  const xA = toRad(fromPoint.lat)
+  const yA = toRad(fromPoint.lng)
+  const xB = toRad(toPoint.lat)
+  const yB = toRad(toPoint.lng)
   const deltaY = yB - yA
 
   if (xA === xB && yA === yB) {
@@ -46,46 +41,14 @@ const calcDistance = (
   ), 1) * EARTHS_RADIUS_IN_METERS
 }
 
-const decoratePoint = (prevDistance, point, prev, next) => {
-  const [lat, lng] = point
-  const distance = prev
-    ? prevDistance + calcDistance(prev, point)
-    : 0
-  const bearing = next
-    ? calcBearing(point, next)
-    : 0
-
-  return {
-    lat,
-    lng,
-    distance,
-    bearing
-  }
-}
-
-const decoratePoints = (
-  decorated,
-  point,
-  index,
-  points
-) => {
-  const prev = points[index - 1]
-  const next = points[index + 1]
-
-  const prevDistance = (decorated[decorated.length - 1] || { distance: 0 }).distance
-
-  decorated.push(decoratePoint(
-    prevDistance,
-    point,
-    prev,
-    next
-  ))
-
-  return decorated
-}
-
 const polylineToPoints = (routeGeometry = '') => (
-  decode(routeGeometry).reduce(decoratePoints, [])
+  decode(routeGeometry).map((point) => {
+    const [lat, lng] = point
+    return {
+      lat,
+      lng
+    }
+  })
 )
 
 const buildWaypoints = (waypoints) => waypoints.map(point => `${point.lng},${point.lat}`).join(';')
@@ -94,5 +57,8 @@ const buildUrl = ({ waypoints = [] }) => `https://router.project-osrm.org/route/
 
 export const findRoute = ({ waypoints = [] }) => (
   axios(buildUrl({ waypoints }))
-    .then(({ data }) => polylineToPoints(data.routes[0].geometry))
+    .then(({ data }) => ({
+      points: polylineToPoints(data.routes[0].geometry),
+      distance: data.routes[0].distance
+    }))
 )


### PR DESCRIPTION
Bearing and Distance are no longer included the routes store. Instead they are calculated on the fly.

Distance - the function that calculates the distance between two points is memoized, using the pair of lat/lngs to create the hash that it uses to lookup results.

Bearing - this is just calculated as needed. Route segments are small, and we only need to know the bearing for a point, when a tourer is on that specific point, so I thought any sort of optimisation would be unnecessary.

Not 100% happy with that findTourerStartingPoint function. I couldn't come up with a better way to do it, given I wanted to exit the iteration once we had reached the point we wanted, and needing to return not just that point, but the leftover distance etc.
