### PR TITLE
Refresh the focus on tourer when updated

### DIFF
--- a/source/components/Map/index.js
+++ b/source/components/Map/index.js
@@ -227,7 +227,13 @@ class Map extends React.Component {
     return global.L.divIcon(icon)
   }
 
-  updateTourer (tourer, routes = []) {
+  focusOnTourer (point, zoom = 10) {
+    this._map.fitBounds([
+      point
+    ], { maxZoom: zoom })
+  }
+
+  updateTourer (tourer, routes = [], selected, focusMode, zoom) {
     const { marker, popup = {}, distance } = tourer
     const point = calcTourerPosition(distance, routes)
     const icon = this.iconForTourer(tourer)
@@ -235,6 +241,10 @@ class Map extends React.Component {
     marker.setLatLng(point)
     marker.setIcon(icon)
     marker.tourer_id = tourer.id
+
+    if (focusMode === 'selected' && tourer.id === selected) {
+      this.focusOnTourer(point, zoom)
+    }
 
     return { ...tourer }
   }
@@ -252,16 +262,17 @@ class Map extends React.Component {
       if (!existingTourer) {
         return this.createTourer(nextTourer, combinedRoutes, selected, focusMode, zoom)
       } else {
-        return this.updateTourer({
+        const tourer = {
           ...existingTourer,
           ...nextTourer,
           marker: existingTourer.marker
-        }, combinedRoutes)
+        }
+        return this.updateTourer(tourer, combinedRoutes, selected, focusMode, zoom)
       }
     })
   }
 
-  createTourer (tourer = {}, routes = [], selected, focusMode, zoom = 10) {
+  createTourer (tourer = {}, routes = [], selected, focusMode, zoom) {
     const { distance, popup } = tourer
     const point = calcTourerPosition(distance, routes)
     const icon = this.iconForTourer(tourer)
@@ -282,9 +293,7 @@ class Map extends React.Component {
     this._markers.addLayer(marker)
 
     if (focusMode === 'selected' && tourer.id === selected) {
-      this._map.fitBounds([
-        point
-      ], { maxZoom: zoom })
+      this.focusOnTourer(point, zoom)
     }
 
     return {


### PR DESCRIPTION
**Problem**

For events where there is a single cumulative tourer, we use the focusMode prop to center the map on that tourer.

When the page loads with the prefetched state from the last build, the map centers, but when the real time data is then pulled in from the api, the tourer moves along, but the map stays in the same spot, meaning that if the difference is great enough, the tourer moves completely out of shot, and you are left looking on an empty part of the route.

**Solution**

Center the map again when the tourer is updated, when the focusMode is set to 'tourer'